### PR TITLE
fix: validate JSON before writing in download_dataset

### DIFF
--- a/Sample code/Download_all_id_DB_API.py
+++ b/Sample code/Download_all_id_DB_API.py
@@ -72,8 +72,12 @@ def download_dataset(endpoint, filename):
     url = f"{API_BASE}/{endpoint}"
     response = requests.get(url, timeout=HTTP_TIMEOUT)
     response.raise_for_status()
+    try:
+        data = response.json()
+    except ValueError as e:
+        raise RuntimeError(f"Invalid JSON received for {filename}: {e}")
     with open(os.path.join(TARGET_FOLDER, filename), "w", encoding="utf-8") as f:
-        f.write(response.text)
+        json.dump(data, f, ensure_ascii=False, indent=2)
 
 
 def sync():

--- a/Sample code/Download_all_id_DB_GitHub.py
+++ b/Sample code/Download_all_id_DB_GitHub.py
@@ -74,8 +74,12 @@ def download_dataset(filename):
     url = f"{GITHUB_RAW_BASE}/{filename}"
     response = requests.get(url, timeout=HTTP_TIMEOUT)
     response.raise_for_status()
+    try:
+        data = response.json()
+    except ValueError as e:
+        raise RuntimeError(f"Invalid JSON received for {filename}: {e}")
     with open(os.path.join(TARGET_FOLDER, filename), "w", encoding="utf-8") as f:
-        f.write(response.text)
+        json.dump(data, f, ensure_ascii=False, indent=2)
 
 
 def sync():


### PR DESCRIPTION
## Summary
- A truncated or otherwise invalid response body could still reach the file write because `response.raise_for_status()` only checks the HTTP status, not the payload integrity. The corrupted body would then overwrite a known-good local JSON file.
- `download_dataset` now parses the response with `response.json()` before touching disk and only writes the file on a successful parse. The output is serialized from the parsed object, guaranteeing the on-disk file is valid JSON.
- Applied to both sample sync scripts: `Sample code/Download_all_id_DB_API.py` and `Sample code/Download_all_id_DB_GitHub.py`. `fetch_remote_last_update()` was already calling `response.json()` and is left untouched.

## Test plan
- [ ] Run each script against a healthy endpoint and confirm files are written and identical in shape to before (whitespace/indent now normalized).
- [ ] Simulate a truncated response (e.g. proxy that closes mid-body) and confirm the script raises `RuntimeError` and does not overwrite the existing local file.
- [ ] Simulate a 200 response with non-JSON body and confirm the same protection kicks in.