### PR TITLE
refactor: rename sync scripts and add API+GitHub fallback variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Sidecar metadata file that exposes the **server-side last-modification timestamp
 - `aspects` → `id_aspect.json`
 - `measure_units` → `id_measure_unit.json`
 
+**Reference implementations:** ready-to-run Python scripts implementing the smart-diff sync described above are available in [`Sample code/`](Sample%20code/):
+
+- [`sync_id_database_api.py`](Sample%20code/sync_id_database_api.py) — live TigerTag API (real-time freshness).
+- [`sync_id_database_github.py`](Sample%20code/sync_id_database_github.py) — GitHub mirror (auto-synced every 6 h, ~6 h stale, no API traffic).
+- [`sync_id_database_api_or_github.py`](Sample%20code/sync_id_database_api_or_github.py) — API primary with automatic GitHub fallback when the API is unreachable.
+
+Drop one of these next to where you want the JSON files and run it — first run downloads everything, subsequent runs are no-ops when nothing has changed server-side.
+
 ---
 
 ## 2.1 ID TigerTag

--- a/Sample code/sync_id_database_api.py
+++ b/Sample code/sync_id_database_api.py
@@ -13,22 +13,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-# Plug-and-play GitHub-mirror sync for the TigerTag reference JSONs.
+# Plug-and-play live-API sync for the TigerTag reference JSONs.
 #
 # What it does on each run:
-#   1. Fetches last_update.json from this repo's GitHub raw mirror
+#   1. Calls the API's all/last_update endpoint
 #   2. Compares every per-dataset timestamp to the local last_update.json
-#   3. Downloads only the files whose timestamp has changed in the mirror
+#   3. Downloads only the files whose server-side timestamp has changed
 #
 # First run downloads everything; subsequent runs are no-ops when nothing
-# has changed. Drop this script wherever you want the JSON files to live
-# and run it — no other setup needed.
+# has changed server-side. Drop this script wherever you want the JSON
+# files to live and run it — no other setup needed.
 #
-# The mirror is auto-synced with the live TigerTag API every 6 hours by a
-# GitHub Actions workflow, so the data is at most ~6 h stale. Use this
-# variant when you don't need real-time freshness — it offloads bandwidth
-# from the TigerTag API to the GitHub CDN. For real-time data, use
-# Download_all_id_DB_API.py instead.
+# If you don't need real-time freshness, prefer sync_id_database_github.py:
+# it pulls the same files from the auto-synced GitHub mirror via the GitHub
+# CDN, which avoids any load on the TigerTag API. If you want real-time data
+# but still want sync to keep working when the API is down, use
+# sync_id_database_api_or_github.py (API primary, GitHub fallback).
 
 import json
 import os
@@ -36,18 +36,18 @@ import sys
 
 import requests
 
-GITHUB_RAW_BASE = "https://raw.githubusercontent.com/TigerTag-Project/TigerTag-RFID-Guide/main/database"
+API_BASE = "https://api.tigertag.io/api:tigertag"
 HTTP_TIMEOUT = 30
 
-# last_update key  ->  filename (same on both the GitHub mirror and locally)
+# last_update key  ->  (API endpoint path,           local filename)
 DATASETS = {
-    "versions":           "id_version.json",
-    "types":              "id_type.json",
-    "brands":             "id_brand.json",
-    "filament_diameters": "id_diameter.json",
-    "filament_materials": "id_material.json",
-    "aspects":            "id_aspect.json",
-    "measure_units":      "id_measure_unit.json",
+    "versions":           ("version/get/all",            "id_version.json"),
+    "types":              ("type/get/all",               "id_type.json"),
+    "brands":             ("brand/get/all",              "id_brand.json"),
+    "filament_diameters": ("diameter/filament/get/all",  "id_diameter.json"),
+    "filament_materials": ("material/get/all",           "id_material.json"),
+    "aspects":            ("aspect/get/all",             "id_aspect.json"),
+    "measure_units":      ("measure_unit/get/all",       "id_measure_unit.json"),
 }
 
 TARGET_FOLDER = os.path.dirname(os.path.abspath(__file__))
@@ -65,13 +65,13 @@ def load_local_last_update():
 
 
 def fetch_remote_last_update():
-    response = requests.get(f"{GITHUB_RAW_BASE}/last_update.json", timeout=HTTP_TIMEOUT)
+    response = requests.get(f"{API_BASE}/all/last_update", timeout=HTTP_TIMEOUT)
     response.raise_for_status()
     return response.json(), response.text
 
 
-def download_dataset(filename):
-    url = f"{GITHUB_RAW_BASE}/{filename}"
+def download_dataset(endpoint, filename):
+    url = f"{API_BASE}/{endpoint}"
     response = requests.get(url, timeout=HTTP_TIMEOUT)
     response.raise_for_status()
     try:
@@ -87,13 +87,13 @@ def sync():
     local_data = load_local_last_update()
 
     updated = []
-    for key, filename in DATASETS.items():
+    for key, (endpoint, filename) in DATASETS.items():
         remote_ts = remote_data.get(key)
         local_ts = local_data.get(key)
         local_file = os.path.join(TARGET_FOLDER, filename)
 
         if remote_ts is None:
-            print(f"[skip] {key}: not present in mirror last_update payload")
+            print(f"[skip] {key}: not present in API last_update payload")
             continue
 
         if remote_ts == local_ts and os.path.exists(local_file):
@@ -101,7 +101,7 @@ def sync():
             continue
 
         print(f"[sync] {filename}: {local_ts} -> {remote_ts}")
-        download_dataset(filename)
+        download_dataset(endpoint, filename)
         updated.append(filename)
 
     if updated or local_data != remote_data:
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     try:
         changed = sync()
     except requests.RequestException as exc:
-        print(f"error: GitHub request failed: {exc}", file=sys.stderr)
+        print(f"error: API request failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
     if changed:

--- a/Sample code/sync_id_database_api_or_github.py
+++ b/Sample code/sync_id_database_api_or_github.py
@@ -13,20 +13,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-# Plug-and-play live-API sync for the TigerTag reference JSONs.
+# Plug-and-play sync for the TigerTag reference JSONs with API primary
+# and GitHub mirror fallback.
 #
 # What it does on each run:
-#   1. Calls the API's all/last_update endpoint
-#   2. Compares every per-dataset timestamp to the local last_update.json
-#   3. Downloads only the files whose server-side timestamp has changed
+#   1. Tries the live TigerTag API for the all/last_update manifest
+#   2. If the API is unreachable (network error, timeout, HTTP 4xx/5xx, or
+#      invalid JSON body), falls back to the GitHub mirror for the rest of
+#      the run so the manifest and the dataset downloads stay coherent
+#   3. Compares every per-dataset timestamp to the local last_update.json
+#   4. Downloads only the files whose timestamp has changed on the chosen
+#      source
 #
-# First run downloads everything; subsequent runs are no-ops when nothing
-# has changed server-side. Drop this script wherever you want the JSON
-# files to live and run it — no other setup needed.
-#
-# If you don't need real-time freshness, prefer Download_all_id_DB_GitHub.py:
-# it pulls the same files from the auto-synced GitHub mirror via the GitHub
-# CDN, which avoids any load on the TigerTag API.
+# Use this script when you want real-time data but still want sync to keep
+# working during an API outage. For pure-API see sync_id_database_api.py;
+# for the mirror only (no API traffic, ~6 h stale) see
+# sync_id_database_github.py.
 
 import json
 import os
@@ -35,9 +37,10 @@ import sys
 import requests
 
 API_BASE = "https://api.tigertag.io/api:tigertag"
+GITHUB_RAW_BASE = "https://raw.githubusercontent.com/TigerTag-Project/TigerTag-RFID-Guide/main/database"
 HTTP_TIMEOUT = 30
 
-# last_update key  ->  (API endpoint path,           local filename)
+# last_update key  ->  (API endpoint path, filename on disk and GitHub mirror)
 DATASETS = {
     "versions":           ("version/get/all",            "id_version.json"),
     "types":              ("type/get/all",               "id_type.json"),
@@ -62,14 +65,41 @@ def load_local_last_update():
         return {}
 
 
-def fetch_remote_last_update():
-    response = requests.get(f"{API_BASE}/all/last_update", timeout=HTTP_TIMEOUT)
+def fetch_json(url):
+    response = requests.get(url, timeout=HTTP_TIMEOUT)
     response.raise_for_status()
     return response.json(), response.text
 
 
-def download_dataset(endpoint, filename):
-    url = f"{API_BASE}/{endpoint}"
+def pick_source():
+    """Return (source_name, last_update_data, last_update_text, dataset_url_for).
+
+    dataset_url_for is a callable (endpoint, filename) -> URL pointing at the
+    chosen source.
+    """
+    try:
+        data, text = fetch_json(f"{API_BASE}/all/last_update")
+        return (
+            "api",
+            data,
+            text,
+            lambda endpoint, filename: f"{API_BASE}/{endpoint}",
+        )
+    except (requests.RequestException, ValueError) as exc:
+        print(
+            f"[warn] API unreachable ({exc}); falling back to GitHub mirror",
+            file=sys.stderr,
+        )
+        data, text = fetch_json(f"{GITHUB_RAW_BASE}/last_update.json")
+        return (
+            "github",
+            data,
+            text,
+            lambda endpoint, filename: f"{GITHUB_RAW_BASE}/{filename}",
+        )
+
+
+def download_dataset(url, filename):
     response = requests.get(url, timeout=HTTP_TIMEOUT)
     response.raise_for_status()
     try:
@@ -81,7 +111,8 @@ def download_dataset(endpoint, filename):
 
 
 def sync():
-    remote_data, remote_text = fetch_remote_last_update()
+    source, remote_data, remote_text, dataset_url_for = pick_source()
+    print(f"[info] source: {source}")
     local_data = load_local_last_update()
 
     updated = []
@@ -91,7 +122,7 @@ def sync():
         local_file = os.path.join(TARGET_FOLDER, filename)
 
         if remote_ts is None:
-            print(f"[skip] {key}: not present in API last_update payload")
+            print(f"[skip] {key}: not present in {source} last_update payload")
             continue
 
         if remote_ts == local_ts and os.path.exists(local_file):
@@ -99,7 +130,7 @@ def sync():
             continue
 
         print(f"[sync] {filename}: {local_ts} -> {remote_ts}")
-        download_dataset(endpoint, filename)
+        download_dataset(dataset_url_for(endpoint, filename), filename)
         updated.append(filename)
 
     if updated or local_data != remote_data:
@@ -115,7 +146,10 @@ if __name__ == "__main__":
     try:
         changed = sync()
     except requests.RequestException as exc:
-        print(f"error: API request failed: {exc}", file=sys.stderr)
+        print(
+            f"error: both API and GitHub mirror requests failed: {exc}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if changed:

--- a/Sample code/sync_id_database_github.py
+++ b/Sample code/sync_id_database_github.py
@@ -1,0 +1,130 @@
+# TigerTag RFID Guide
+# Copyright (C) 2025 TigerTag
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+# Plug-and-play GitHub-mirror sync for the TigerTag reference JSONs.
+#
+# What it does on each run:
+#   1. Fetches last_update.json from this repo's GitHub raw mirror
+#   2. Compares every per-dataset timestamp to the local last_update.json
+#   3. Downloads only the files whose timestamp has changed in the mirror
+#
+# First run downloads everything; subsequent runs are no-ops when nothing
+# has changed. Drop this script wherever you want the JSON files to live
+# and run it — no other setup needed.
+#
+# The mirror is auto-synced with the live TigerTag API every 6 hours by a
+# GitHub Actions workflow, so the data is at most ~6 h stale. Use this
+# variant when you don't need real-time freshness — it offloads bandwidth
+# from the TigerTag API to the GitHub CDN. For real-time data, use
+# sync_id_database_api.py instead. For real-time data with automatic
+# GitHub fallback when the API is unreachable, use
+# sync_id_database_api_or_github.py.
+
+import json
+import os
+import sys
+
+import requests
+
+GITHUB_RAW_BASE = "https://raw.githubusercontent.com/TigerTag-Project/TigerTag-RFID-Guide/main/database"
+HTTP_TIMEOUT = 30
+
+# last_update key  ->  filename (same on both the GitHub mirror and locally)
+DATASETS = {
+    "versions":           "id_version.json",
+    "types":              "id_type.json",
+    "brands":             "id_brand.json",
+    "filament_diameters": "id_diameter.json",
+    "filament_materials": "id_material.json",
+    "aspects":            "id_aspect.json",
+    "measure_units":      "id_measure_unit.json",
+}
+
+TARGET_FOLDER = os.path.dirname(os.path.abspath(__file__))
+LAST_UPDATE_PATH = os.path.join(TARGET_FOLDER, "last_update.json")
+
+
+def load_local_last_update():
+    if not os.path.exists(LAST_UPDATE_PATH):
+        return {}
+    try:
+        with open(LAST_UPDATE_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def fetch_remote_last_update():
+    response = requests.get(f"{GITHUB_RAW_BASE}/last_update.json", timeout=HTTP_TIMEOUT)
+    response.raise_for_status()
+    return response.json(), response.text
+
+
+def download_dataset(filename):
+    url = f"{GITHUB_RAW_BASE}/{filename}"
+    response = requests.get(url, timeout=HTTP_TIMEOUT)
+    response.raise_for_status()
+    try:
+        data = response.json()
+    except ValueError as e:
+        raise RuntimeError(f"Invalid JSON received for {filename}: {e}")
+    with open(os.path.join(TARGET_FOLDER, filename), "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def sync():
+    remote_data, remote_text = fetch_remote_last_update()
+    local_data = load_local_last_update()
+
+    updated = []
+    for key, filename in DATASETS.items():
+        remote_ts = remote_data.get(key)
+        local_ts = local_data.get(key)
+        local_file = os.path.join(TARGET_FOLDER, filename)
+
+        if remote_ts is None:
+            print(f"[skip] {key}: not present in mirror last_update payload")
+            continue
+
+        if remote_ts == local_ts and os.path.exists(local_file):
+            print(f"[ok]   {filename}: up to date ({remote_ts})")
+            continue
+
+        print(f"[sync] {filename}: {local_ts} -> {remote_ts}")
+        download_dataset(filename)
+        updated.append(filename)
+
+    if updated or local_data != remote_data:
+        with open(LAST_UPDATE_PATH, "w", encoding="utf-8") as f:
+            f.write(remote_text)
+        if "last_update.json" not in updated:
+            updated.append("last_update.json")
+
+    return updated
+
+
+if __name__ == "__main__":
+    try:
+        changed = sync()
+    except requests.RequestException as exc:
+        print(f"error: GitHub request failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if changed:
+        print(f"\nUpdated {len(changed)} file(s):")
+        for name in changed:
+            print(f"  {name}")
+    else:
+        print("\nAll datasets already up to date.")


### PR DESCRIPTION
## Summary
- Rename the two existing sample sync scripts to follow a consistent `sync_id_database_<source>.py` scheme:
  - `Download_all_id_DB_API.py` → `sync_id_database_api.py`
  - `Download_all_id_DB_GitHub.py` → `sync_id_database_github.py`

  The previous names suggested a bulk download, but both scripts actually do an incremental sync against the `last_update.json` manifest. The new names match what they do, use snake_case (PEP 8) and parallel each other so the variants are obvious.
- Add a third variant `sync_id_database_api_or_github.py` that tries the live TigerTag API first and falls back to the GitHub mirror for the rest of the run when the API is unreachable (network error, timeout, HTTP 4xx/5xx via `raise_for_status`, or invalid JSON for the manifest).
- The fallback decision is made **once per run**, at manifest-fetch time. Same source is used for the dataset downloads that follow, so the `last_update.json` written to disk stays coherent with the dataset contents next to it. If both sources fail, the request error propagates and the script exits non-zero.
- The new script reuses the JSON-validation pattern from the recently merged security fix (parse before write).
- Cross-references inside the docstring headers of the two renamed scripts were updated to point at the new filenames and to mention the new fallback variant.

## Test plan
- [ ] Run `sync_id_database_api.py` and confirm it behaves identically to before the rename (only the filename changed).
- [ ] Run `sync_id_database_github.py` and confirm the same.
- [ ] Run `sync_id_database_api_or_github.py` with the API reachable → confirm `[info] source: api` and that no GitHub request is made.
- [ ] Block `api.tigertag.io` (e.g. `/etc/hosts` to `127.0.0.1`) and re-run → confirm `[warn] API unreachable ...; falling back to GitHub mirror`, `[info] source: github`, and that the resulting `last_update.json` matches the GitHub mirror's manifest.
- [ ] Re-run with the API reachable again → confirm any datasets whose API timestamp is newer than the GitHub-written value are re-downloaded.
- [ ] Block both sources → confirm the script exits 1 with `error: both API and GitHub mirror requests failed`.