### PR TITLE
docs: restructure Apps & Tools and add Community Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,23 @@ To request commercial rights, OEM access, or brand guidelines, please contact us
 ---
 
 
-## 5.0 Developer Notice on the Mobile App
+## 5.0 Apps & Tools
+
+TigerTag is built around an open protocol and a free public API. Below are the official **TigerTag-Project apps and tools** — all open-source where indicated — that consume that API. For developer references, the protocol specification is the rest of this document; the API is documented at [https://api.tigertag.io/api:tigertag](https://api.tigertag.io/api:tigertag), and the project website is [https://tigertag.io](https://tigertag.io).
+
+## 5.1 TigerTag Studio Manager (Open Source)
+
+Desktop application for **Windows, macOS, and Linux** that manages your 3D-printing filament inventory. It reads RFID spool tags through an ACR122U NFC reader, tracks remaining weight, and surfaces print temperatures, MSDS/TDS links, and product details. Auto-updates via GitHub Releases.
+
+🔗 [TigerTag-Project/TigerTag-Studio-Manager](https://github.com/TigerTag-Project/TigerTag-Studio-Manager) — built with Electron.
+
+## 5.2 Tiger Scale (Open Source)
+
+DIY smart scale (~30 € BoM) that identifies which spool sits on it. Drop a spool with a TigerTag NFC sticker on the platform — the scale reads the tag, weighs the spool, computes the **net filament weight** (subtracting the empty spool), and syncs the result to your TigerTag account in real time. Dual RC522 RFID readers for twin-tag spools, HX711 + 5 kg load cell, OLED display, mobile-friendly web UI served by the ESP32 itself, 9-language UI.
+
+🔗 [TigerTag-Project/Tiger_Scale](https://github.com/TigerTag-Project/Tiger_Scale) — ESP32 / Arduino / PlatformIO, with a one-click [Web Installer](https://tigertag-project.github.io/Tiger_Scale/) (Chrome/Edge).
+
+## 5.3 TigerTag RFID Connect — Mobile Apps (iOS & Android)
 
 The official TigerTag mobile app (iOS and Android) is a **closed-source proof of concept** provided for convenience. It demonstrates how TigerTag tags can be read and written using the open protocol.
 
@@ -502,21 +518,38 @@ The TigerTag mobile app uses only the **free public API** to ensure fair access 
 
 For protocol details, refer to the sections above or contact us for technical guidance.
 
-## 5.1 API & Documentation Links
-
-For developers and integrators, here are quick access links:
-
-- 🔗 Official Website: [https://tigertag.io](https://tigertag.io)
-- 📘 Swagger API Documentation: [https://api.tigertag.io/api:tigertag](https://api.tigertag.io/api:tigertag)
-
 ### 📱 Mobile Apps
 
-<img src="Images/TigerTag_RFID_Connect_Apps.png" alt="TigerTag Mobile Apps">
+<img src="https://raw.githubusercontent.com/TigerTag-Project/TigerTag-RFID-Guide/main/Images/TigerTag_RFID_Connect_Apps.png" alt="TigerTag Mobile Apps">
 
 - 🧭 iOS App: [https://apps.apple.com/fr/app/tigertag-rfid-connect/id6745437963](https://apps.apple.com/fr/app/tigertag-rfid-connect/id6745437963)
 - 🤖 Android App: [https://play.google.com/store/apps/details?id=com.tigertag.connect](https://play.google.com/store/apps/details?id=com.tigertag.connect)
 
-## 6. Version History
+---
+
+## 6. Community Integrations & Acknowledgments
+
+Third-party projects built on the TigerTag protocol or the public API. These are independent community efforts — they are **not officially maintained or endorsed by TigerTag Project** — and we list them here as a thank-you to their authors for extending the TigerTag ecosystem.
+
+## 6.1 OpenRFID
+
+RFID controller and parsing library for common 3D-printing filament tags, with native support for the **TigerTag** format (alongside OpenSpool, OpenTag3D, and others). Marked by the author as a work in progress.
+
+🔗 [suchmememanyskill/OpenRFID](https://github.com/suchmememanyskill/OpenRFID) — author: [@suchmememanyskill](https://github.com/suchmememanyskill). Python.
+
+## 6.2 Snapmaker U1 Extended Firmware
+
+Custom and repackaged firmware for the **Snapmaker U1** 3D printer, adding debug features (SSH access) and extended capabilities. RFID filament-tag support is provided via an embedded **OpenRFID** module, which is what brings TigerTag parsing to the printer.
+
+🔗 [paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware) — author: [@paxx12](https://github.com/paxx12). Independent of, and not affiliated with, Snapmaker.
+
+## 6.3 TigerTag — Home Assistant Integration
+
+HACS-compatible custom integration that synchronises your TigerTag filament inventory into **Home Assistant**: sensors and number entities per spool, custom Lovelace card, twin-tag deduplication, rack/level/position assignment, optional integration with [ha-bambulab](https://github.com/greghesp/ha-bambulab) to push filament configuration to a Bambu Lab AMS.
+
+🔗 [Kenny3231/TigerTag](https://github.com/Kenny3231/TigerTag) — author: [@Kenny3231](https://github.com/Kenny3231). Per its own README, this is a community project **not officially affiliated with TigerTag Project**.
+
+## 7. Version History
 
 | Version | Date       | Description           | Author        |
 | ------- | ---------- | --------------------- | ------------- |
@@ -524,7 +557,7 @@ For developers and integrators, here are quick access links:
 
 ---
 
-## 7. Contributions
+## 8. Contributions
 
 Want to contribute improvements or integrations? Fork this repository and open a pull request.
 


### PR DESCRIPTION
## Summary

**Section 5 — Apps & Tools (restructure).** The previous layout had a flat *5.0 Developer Notice* + *5.1 API & Documentation Links* block that only documented the mobile-app proof of concept. It is reshaped into a proper Apps & Tools section that also showcases the open-source companion projects:

- **5.0** *Apps & Tools* — preamble. Absorbs the existing Website and Swagger links (transversal to all apps).
- **5.1** *TigerTag Studio Manager (Open Source)* — Electron desktop app for Win/macOS/Linux, RFID inventory via ACR122U.
- **5.2** *Tiger Scale (Open Source)* — ESP32 / RC522 / HX711 smart scale with cloud sync, OLED, mobile-friendly web UI, web installer.
- **5.3** *TigerTag RFID Connect — Mobile Apps (iOS & Android)* — preserves the existing *Developer Notice on the Mobile App* paragraph block **verbatim** (closed-source POC disclaimer, ✅/✅/🔒 bullet points, the free-public-API paragraph, the trailing 'For protocol details…' line), then continues with the *📱 Mobile Apps* image + store links. The image src was switched from the repo-relative path to the absolute `raw.githubusercontent.com` URL so it renders correctly outside `github.com` mirrors (e.g. when the README is rendered in third-party tools).

**Section 6 — Community Integrations & Acknowledgments (new).** Lists independent community projects built on the TigerTag protocol or the public API. Each entry carries an explicit *not officially maintained or endorsed by TigerTag Project* disclaimer so the boundary between official and community work is unambiguous (especially relevant for the Home Assistant integration, which ships the same disclaimer in its own README):

- **6.1** *OpenRFID* ([suchmememanyskill](https://github.com/suchmememanyskill/OpenRFID)) — Python parsing library; verified to ship a dedicated `src/tag/tigertag/` module with registry, processor, database and test fixtures.
- **6.2** *Snapmaker U1 Extended Firmware* ([paxx12](https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware)) — custom Snapmaker U1 firmware that embeds OpenRFID (`overlays/firmware-extended/64-app-openrfid/`); described as such so the indirect TigerTag support chain (firmware → OpenRFID → TigerTag) is honest.
- **6.3** *TigerTag — Home Assistant Integration* ([Kenny3231](https://github.com/Kenny3231/TigerTag)) — HACS-compatible custom integration syncing the TigerTag inventory into Home Assistant, with optional Bambu Lab AMS push via `ha-bambulab`.

**Renumbering.** The two trailing sections shift down: *Version History* moves from 6 to 7, *Contributions* moves from 7 to 8. Grepping the README confirmed no body text cross-references those numbers, so no inbound links break.

## Test plan

- [x] Render the README on github.com and visually check the new headings 5.0 / 5.1 / 5.2 / 5.3 / 6 / 6.1 / 6.2 / 6.3 / 7 / 8 appear in order.
- [x] Verify the *📱 Mobile Apps* image now loads from the absolute raw URL (and still loads on github.com).
- [x] Verify the verbatim *Developer Notice* block (closed-source POC disclaimer, ✅/✅/🔒 bullets, free-public-API paragraph, trailing 'For protocol details…' line) is preserved word-for-word under 5.3.
- [x] Click each of the eight external GitHub links (Studio Manager, Tiger Scale + Web Installer, OpenRFID, Snapmaker firmware, Home Assistant integration, ha-bambulab) and confirm they resolve.
- [x] Confirm the two community disclaimers ('not officially maintained or endorsed by TigerTag Project', 'not officially affiliated with TigerTag Project') are present and visible at section level and on the Kenny3231 entry.