### PR TITLE
docs: link the wiki, and separate the chip type ids from the identity lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ the chip — HueForge reads it without any manual entry.
   TigerTag is the only NFC/RFID protocol supported natively by **TD1s by Ajax**.
 - TD1s hardware (AJAX TD1S V1.0) available:
     - Atome3D.com — https://www.atome3d.com/products/biqu-ajax-td1s-v1-0
-    - Tigertag.io — https://tigertag.io/fr/products/biqu-ajax-td1s-v1-0
+    - Tigertag.io — https://shop.tigertag.io/products/biqu-ajax-td1s-v1-0
 
 ---
 
@@ -735,7 +735,10 @@ signed message from exactly three binary parts:
 - **block4** — page `0x04`, bytes 0–3: ID TigerTag (`u32 BE`, 4 bytes).
 - **block5** — page `0x05`, bytes 0–3: ID Product (`u32 BE`, 4 bytes).
 
-Signed message: `SHA-256( UID_bytes + block4 + block5 )` → 15 bytes total.
+Concatenate in that order — `UID_bytes + block4 + block5`, **15 bytes**
+— and sign the SHA-256 of that concatenation. The 15 bytes are the
+input to the hash, not the size of the digest and not the size of the
+signature (which is 64 bytes: `r` and `s`, 32 each).
 
 The public key is stored in `database/id_version.json` under the
 `public_key` field of the entry matching the tag's `ID TigerTag`

--- a/README.md
+++ b/README.md
@@ -327,14 +327,21 @@ above, and do not expect `TigerTag Init` to appear on the wiki. Parsers
 and firmware care only about this axis — the type id on the chip.
 
 > ⚠️ **Known divergence.** The two documents do not currently agree on
-> what makes a chip a `TigerTag+`. This guide defines it as the `ID
-> TigerTag` value `0xBC0FCB97`, written by partner brands, carrying an
-> ECDSA-P256 signature (§3). The wiki defines it as an account-level
-> state. The question is open in
+> what makes a chip a `TigerTag+`. In this repository it is the `ID
+> TigerTag` value `0xBC0FCB97` at page `0x04` — four bytes, read
+> offline. On the wiki it is an account-level state, which is not
+> readable from the chip at all. The question is open in
 > [#11](https://github.com/TigerTag-Project/TigerTag-RFID-Guide/issues/11)
-> and this section does not settle it. Until it is settled, read every
-> use of `TigerTag+` **in this repository** as referring to the type id
-> at page `0x04`, and nothing else.
+> and this section does not settle it.
+>
+> Note that the ECDSA-P256 signature of [§3](#3-verify-signature-ecdsa-p256-fully-offline)
+> is **optional and independent** of the type id. A `TigerTag+` written
+> by a partner brand carries one, so its origin can be proved offline; a
+> `TigerTag+` created from the SDK or from Tiger Studio may carry none,
+> and is no less a `TigerTag+` — nothing simply proves where it came
+> from. Read every use of `TigerTag+` **in this repository** as the type
+> id at page `0x04`, never as a claim that the chip is signed. That
+> claim is a separate test, on the signature pages themselves.
 
 ### Chip memory map
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <p align="center">
   <a href="https://tigersystem.io">tigersystem.io</a>
   ·
+  <a href="https://wiki.tigersystem.io">Documentation wiki</a>
+  ·
   <a href="https://api.tigertag.io/api:tigertag">Public API</a>
   ·
   <a href="#5-ecosystem--official-tools-and-hardware">Ecosystem</a>
@@ -35,6 +37,22 @@
 > the material, the brand, the print settings, the remaining quantity,
 > and proves the spool is genuine with a cryptographic signature —
 > all **fully offline** and **free for users**.
+
+---
+
+## Where to start
+
+| If you want to | Go to |
+| -------------- | ----- |
+| Understand what TigerTag is, set up a first spool, browse products, or follow a guide | **[wiki.tigersystem.io](https://wiki.tigersystem.io)** — the documentation site |
+| Write a parser, a writer or a firmware — byte offsets, field types, signature verification | **This repository** — the normative specification |
+
+The wiki is the reader's entry point and explains the ecosystem in prose.
+This guide is the **normative reference for the binary format**: where a
+field sits on the chip, how wide it is, how it is encoded, and how a
+signature is verified. Where the two disagree on a byte, an offset or a
+field type, **this repository wins** — see
+[§2 — Data Structure](#2-data-structure--tigertag-binary-format).
 
 ---
 
@@ -277,6 +295,46 @@ variants remain compatible because the extra pages are simply unused.
 > The canonical names are **TigerTag**, **TigerTag+**, and **TigerTag Init**.
 > `Offline` is an operating mode of standard TigerTag tags, **not** a
 > protocol name — do not use it as a substitute label.
+
+### TigerTag Init and the identity lifecycle
+
+Two models are in circulation and they are frequently merged into one.
+They describe different objects.
+
+- **The three types above describe what is written on the chip.** The
+  type is the value of the 4-byte `ID TigerTag` field at page `0x04`
+  (see [§2.1](#21-id-tigertag)). It is a property of chip memory, read
+  offline, in one page, with no account and no network.
+- **The identity lifecycle describes the state of the record**, from
+  `TigerData` (an identity that exists only digitally, before any chip)
+  through to the account-level states. It is documented on the wiki:
+  [Universal Filament Identity](https://wiki.tigersystem.io/concepts/universal-filament-identity/).
+
+These are two axes, not two halves of one sequence. A spool has one
+value on each: a chip format, and a record state. Neither list is a
+longer or shorter version of the other, and a chip's type id cannot be
+derived from the lifecycle state or the reverse.
+
+`TigerTag Init` is a chip state with no counterpart on the lifecycle
+axis. It marks a chip that has been prepared but carries no identity
+yet — nothing about the material has been decided, so there is no record
+to be in any state. Symmetrically, the lifecycle's pre-chip states have
+no `ID TigerTag` value at all, because by definition nothing has been
+written to a chip.
+
+**So:** do not read a three-state progression out of the type table
+above, and do not expect `TigerTag Init` to appear on the wiki. Parsers
+and firmware care only about this axis — the type id on the chip.
+
+> ⚠️ **Known divergence.** The two documents do not currently agree on
+> what makes a chip a `TigerTag+`. This guide defines it as the `ID
+> TigerTag` value `0xBC0FCB97`, written by partner brands, carrying an
+> ECDSA-P256 signature (§3). The wiki defines it as an account-level
+> state. The question is open in
+> [#11](https://github.com/TigerTag-Project/TigerTag-RFID-Guide/issues/11)
+> and this section does not settle it. Until it is settled, read every
+> use of `TigerTag+` **in this repository** as referring to the type id
+> at page `0x04`, and nothing else.
 
 ### Chip memory map
 


### PR DESCRIPTION
Documentation only. No normative statement about the binary format is
changed, and nothing here settles the open question in #11.

## 1. The wiki is now linked back

`wiki.tigersystem.io` points at this organisation; nothing here pointed
at the wiki. A new **Where to start** section splits the two roles: the
wiki is the reader's entry point (what TigerTag is, first spool,
products, guides), this repository is the normative reference for the
binary format. Precedence is stated rather than implied — on a byte, an
offset or a field type, this repository wins. The wiki also joins the
link row in the header.

## 2. Chip types vs identity lifecycle

This guide knows three type ids (TigerTag, TigerTag+, TigerTag Init).
The wiki describes a four-state identity lifecycle (TigerData →
TigerData+ → TigerTag → TigerTag+) and never mentions TigerTag Init.

They are not the same object — one is the state of the *record*, the
other is what is *written on the chip* — but nowhere was that said, so
readers merge the two lists and then try to reconcile three against
four. That has already produced a wrong three-state model published by
an outside contributor.

New section **TigerTag Init and the identity lifecycle** (§1) states the
two axes, explains why TigerTag Init has no lifecycle counterpart and
why the pre-chip states have no type id, and tells parser authors that
only the type id concerns them. The lifecycle itself is **linked, not
duplicated** — it stays owned by
[TigerSystem-Docs](https://wiki.tigersystem.io/concepts/universal-filament-identity/).

The section carries a **Known divergence** callout: the two documents do
not agree on what makes a chip a `TigerTag+`, that is a product decision
tracked in #11, and this PR does not make it. Until it is made, every
use of `TigerTag+` in this repository is to be read as the `ID TigerTag`
value at page `0x04`.

## 3. Two incidental fixes

- **Dead link.** The Tigertag.io TD1s link (§2.10) had moved to
  `shop.tigertag.io` and was answering 404 — `docs-check` was red on it.
- **Ambiguous wording.** §3 read `SHA-256( UID + block4 + block5 ) → 15
  bytes total`, which parses as a 15-byte digest. The 15 bytes are the
  concatenation fed to the hash — 7 + 4 + 4. Reworded, with the 64-byte
  signature size stated alongside so the two numbers cannot be swapped.
  The `(7) + (4) + (4)` copies in `llms.txt` and the quick reference were
  already unambiguous and are untouched.

## Checks

`python3 tools/docs_check.py` passes in full, external links included.
It was failing on the TD1s link before this branch.

## Not in this PR

- The `TigerTag+` definition — #11.
- `llms.txt`, which has unrelated uncommitted work in progress locally.
