### PR TITLE
docs: fix TRADEMARK.md contradicting itself, and the hand-copied version tags

### DIFF
--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -175,22 +175,28 @@ the logo descriptively; it is not a copyright licence to the artwork.
 | Name your company or domain "TigerTag" | ❌ No (trademark) |
 | Create a competing RFID protocol called "TigerTag" | ❌ No (trademark) |
 | Issue or forge a TigerTag+ signature | ❌ No (key custody) |
-| Label your tag "TigerTag+" without a valid signature | ❌ No (trademark + misrepresentation) |
+| Label your tag "TigerTag+" — a catalogue product id, no signature needed | ✅ Yes |
+| Label your tag "TigerTag+ **Certified**" without a valid signature | ❌ No (trademark + misrepresentation) |
 | Claim TigerTag certification without agreement | ❌ No — see [`LICENSE_COMMERCIAL.md`](LICENSE_COMMERCIAL.md) |
 
 ---
 
 ## Official integration
 
-Two marks, and only one of them needs us:
+Three words, and only one of them needs us:
 
-| | **TigerTag Compatible** | **TigerTag Certified** |
-|---|---|---|
-| For | Readers, apps, printers, slicers — anything that **talks to** TigerTag | Anything that **is** a TigerTag: filament and resin manufacturers, inlay and carrier producers, machine makers whose product writes TigerTag identities |
-| Audit | None | **Required** |
-| Cost | Free | **Paid** |
-| Logo | In your app, docs, store listing | **On the product, the chip, the packaging** |
-| Signatures, product-ID, public listing | — | Yes |
+- **Official** — made by TigerSystem. A statement of origin, not a mark that gets granted.
+- **Certified** — made by a third party, audited and validated by TigerSystem. Open to
+  anything a third party builds, hardware or software alike: the line is whether anyone
+  checked, not what the product is.
+- **Compatible** — made by a third party, self-declared. Free, unaudited, no permission
+  needed, and staying that way.
+
+Certification comes in two scopes, **TigerTag Certified** and **TigerTag+ Certified**, the
+second covering verified handling of signed tags. Who may claim what, what the audit
+verifies, and what each mark costs are defined in
+[`CERTIFICATION.md`](CERTIFICATION.md) — that is where those facts live, and they are not
+restated here.
 
 If you manufacture filament or resin and want **officially supplied TigerTag media**
 (pre-printed carriers), **TigerTag+ signatures**, **product-ID allocation**, the right to put

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -54,15 +54,20 @@ The value written on the chip, in the `id_tigertag` field. It is a `u32` big-end
 identifier, not a human-readable string, and every entry is registered in
 [`database/id_version.json`](database/id_version.json):
 
-| `id` | `version` | `name` | `tag` | Signed |
+| `id` | `version` | `name` | `tag` | Public key |
 |---|---|---|---|---|
 | `0` | `0.0` | RFID Empty | `TIGER_TAG_UNINITIALIZED` | — |
-| `1542820452` | `1.0` | TigerTag | `TIGER_TAG_MAKER_V1.0` | Yes |
+| `1542820452` | `1.0` | TigerTag | `TIGER_TAG_V1.0` | Yes |
 | `1816240865` | `1.0` | TigerTag Init | `TIGER_TAG_INIT` | Yes |
-| `3155151767` | `1.0` | TigerTag+ | `TIGER_TAG_PRO_V1.0` | Yes |
+| `3155151767` | `1.0` | TigerTag+ | `TIGER_TAG_PLUS_V1.0` | Yes |
 
-Each signed entry carries the **public key** used to verify chips of that version, in PEM
-form, in the `public_key` field. This is the mechanism that makes offline verification
+The last column says whether the entry ships a key, **not** whether chips of that version
+are signed. Signing is optional and independent of the format version: a signed tag is a
+`TigerTag+ Certified` (see [`CERTIFICATION.md`](CERTIFICATION.md)), and an unsigned
+`TigerTag+` is normal.
+
+Each entry with a key carries the **public key** used to verify chips of that version, in
+PEM form, in the `public_key` field. This is the mechanism that makes offline verification
 possible: a reader ships with `id_version.json` embedded, reads `id_tigertag` off the chip,
 selects the matching key, and verifies. No network.
 


### PR DESCRIPTION
Documentation only. Two leftovers from #15, both in normative documents.

## `TRADEMARK.md` was contradicting itself

Since #15 merged, the section on "TigerTag+" says:

> Describing an unsigned catalogue tag as "TigerTag+" is correct and always has been intended to be.

while the rules table a hundred lines below still said:

> | Label your tag "TigerTag+" without a valid signature | ❌ No (trademark + misrepresentation) |

One normative document, two opposite answers to the question a reader
opens it to settle. The prohibition belongs to **"TigerTag+ Certified"**,
which is the claim a signature actually backs. The permitted case now has
a line of its own rather than being the absence of a rule.

The same file also carried **a second copy of the certification table**,
still with the "who" row this project moved away from — readers, apps,
printers and slicers parked on the Compatible side by category rather
than by whether anyone had checked. It had already been missed once.
Replaced with the Official / Certified / Compatible summary and a pointer
to `CERTIFICATION.md`, which is where those facts live.

## `VERSIONING.md` hand-copies the version tags

`TIGER_TAG_MAKER_V1.0` and `TIGER_TAG_PRO_V1.0` are renamed to
`TIGER_TAG_V1.0` and `TIGER_TAG_PLUS_V1.0` in the catalogue.
`database/id_version.json` picks that up on its own at the next sync and
is **not touched here** — it is generated, and a hand edit would be
reverted. This table copies the strings by hand and would have stayed
stale indefinitely, in the place an implementer looks to decide what to
match on.

Its last column was headed **"Signed"** with "Yes" on every keyed entry.
It reports whether the entry ships a public key; read as "chips of this
version are signed" it puts the authenticity claim back on the format
version, which is the conflation #15 spent its length removing. Renamed
to "Public key", with the distinction stated once underneath.

## Checks

`tools/docs_check.py` passes.

## Next

The same retired rule still sits in `brand/README.md:32`,
`SECURITY.md:58` and `LICENSE_COMMERCIAL.md:64`. Not in this PR.
