### PR TITLE
ci: run the documentation check over the whole repository

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,23 +1,21 @@
 name: Check documentation
 
 on:
+  # No path filter. The filter used to list README.md, llms.txt and brand/**,
+  # which meant a change to TRADEMARK.md, CERTIFICATION.md, VERSIONING.md or
+  # SECURITY.md ran no check at all — and those are normative documents. A
+  # contradiction between two of them is exactly the kind of thing nobody
+  # notices by reading. Everything is in scope now; the run is seconds.
   pull_request:
-    paths:
-      - 'README.md'
-      - 'llms.txt'
-      - 'Images/**'
-      - 'brand/**'
-      - 'tools/docs_check.py'
-      - '.github/workflows/docs-check.yml'
   push:
     branches: [main]
-    paths:
-      - 'README.md'
-      - 'llms.txt'
-      - 'Images/**'
-      - 'brand/**'
-      - 'tools/docs_check.py'
-      - '.github/workflows/docs-check.yml'
+    # The one exception: the catalogue is synced into this repository several
+    # times a day by sync-database.yml. Those commits cannot affect the
+    # documentation, and re-sweeping every external link on each of them buys
+    # nothing. The weekly schedule below covers link rot regardless.
+    paths-ignore:
+      - 'database/id_*.json'
+      - 'database/last_update.json'
   # An external link rots without anyone touching this repository — the site moves
   # and the link dies quietly. A check that only runs on push would never see it,
   # so this also sweeps once a week.

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -57,7 +57,21 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # so a rename that breaks them has to be caught here too. Their links are written
 # relative to their OWN directory, which is why targets resolve against the
 # document rather than against the repository root.
-DOCS = ["README.md", "llms.txt", "brand/README.md", "database/README.md"]
+DOCS = [
+    "README.md",
+    "llms.txt",
+    "CERTIFICATION.md",
+    "CONTRIBUTING.md",
+    "LICENSE_COMMERCIAL.md",
+    "LICENSING.md",
+    "SECURITY.md",
+    "TRADEMARK.md",
+    "VERSIONING.md",
+    "brand/README.md",
+    "database/README.md",
+    "docs/TRADEMARK-FILING.md",
+    "SpoolmanDB/README.md",
+]
 
 # Docs whose backticked filenames name files sitting in that same directory, so a
 # bare `name.svg` can be resolved and checked. The root README is deliberately not


### PR DESCRIPTION
The documentation check covered four files. Two filters had to agree for
a document to be checked, and both were narrow: the workflow's `paths`
listed `README.md`, `llms.txt`, `Images/**` and `brand/**`, and the
script's own `DOCS` list named four files.

So `TRADEMARK.md`, `CERTIFICATION.md`, `VERSIONING.md`, `SECURITY.md`,
`LICENSING.md`, `LICENSE_COMMERCIAL.md` and `CONTRIBUTING.md` were
checked by nothing — no dead links, no broken anchors, no fact drift —
while being the documents that carry the project's normative claims.

The gap was not theoretical. `TRADEMARK.md` spent several hours on `main`
saying both that an unsigned catalogue tag may be called `TigerTag+` and
that doing so is trademark misuse and misrepresentation (fixed in #16),
and nothing went red. A contradiction between two paragraphs is not
something a reviewer reliably catches, and a dead link in a licence
document is worse than one in a README.

## What changes

- **Workflow:** no `paths` filter on `pull_request` — every PR is checked.
- **Script:** `DOCS` now lists every Markdown document in the repository.

## The one exclusion

`push` to `main` ignores `database/id_*.json` and
`database/last_update.json`. `sync-database.yml` pushes those several
times a day; the commits cannot affect the documentation, and
re-sweeping every external link on each of them buys nothing. The weekly
schedule already covers link rot, which happens without anyone touching
the repository.

## Result

`python3 tools/docs_check.py` passes over all thirteen documents,
external links included. **Nothing was found broken in the newly covered
files** — they were correct, just unverified.