### PR TITLE
docs: finish propagating TigerTag+ vs TigerTag+ Certified

### DIFF
--- a/LICENSE_COMMERCIAL.md
+++ b/LICENSE_COMMERCIAL.md
@@ -61,8 +61,8 @@ Licensee and any third party may, without this Agreement and without payment:
   code, in source form, under the licences stated in [`LICENSING.md`](LICENSING.md)
 - Read, write, and verify TigerTag chips
 
-Such products may not, however, bear the Marks, claim TigerTag+ status, or use Official
-Product IDs, except under this Agreement.
+Such products may not, however, bear the Marks, claim TigerTag+ Certified status, or use
+Official Product IDs, except under this Agreement.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,16 +54,19 @@ Especially anything touching the signature or key handling:
 
 - **Signature forgery** — producing a tag that verifies against a published public key
   without TigerTag Corp's private key
-- **Signature bypass** — causing a reader that follows the specification to accept an
-  unsigned or invalidly signed tag as TigerTag+
+- **Signature bypass** — causing a reader that follows the specification to present an
+  unsigned or invalidly signed tag as **origin-verified**: as a `TigerTag+ Certified`, or
+  as anything a user would read as proof of provenance. Accepting an unsigned tag as a
+  plain `TigerTag+` is correct behaviour and is not a bypass — the `+` is a catalogue
+  identity, not an authenticity claim.
 - **Weakness in the signed message construction** — the signed message is
   `SHA-256(uid[7B] ‖ id_tigertag[4B BE] ‖ id_product[4B BE])`. Collisions, length-extension,
   ambiguity in the concatenation, or any way to make two distinct tags produce the same
   digest are in scope.
 - **Key exposure** — a private key, or material sufficient to derive one, present anywhere
   in this repository, in a published artefact, in the API, or in a shipped tool
-- **Downgrade attacks** — forcing a reader to treat a TigerTag+ chip as an unsigned one, or
-  to select a weaker tag format version
+- **Downgrade attacks** — forcing a reader to treat a validly signed chip as an unsigned
+  one, or to select a weaker tag format version
 - **Public-key substitution** — any path by which a reader can be induced to verify against
   an attacker-controlled key rather than the ones in
   [`database/id_version.json`](database/id_version.json)

--- a/brand/README.md
+++ b/brand/README.md
@@ -29,8 +29,9 @@ a true fact about compatibility:
 - Modify the logo — no recolouring, stretching, cropping, or recomposition.
 - Use "TigerTag" in your product, company, or domain name.
 - Imply affiliation, certification, endorsement, or partner status you do not have.
-- Present your product as "TigerTag+" unless its tags carry a signature issued by
-  TigerTag Corp.
+- Present your product as "TigerTag+ Certified" unless its tags carry a valid signature
+  issued by TigerTag Corp. ("TigerTag+" on its own means the tag carries an official
+  catalogue product id — that is not a claim about origin, and it is not restricted here.)
 
 Full terms: [`../TRADEMARK.md`](../TRADEMARK.md).
 Official partner status and packaging rights: [`../LICENSE_COMMERCIAL.md`](../LICENSE_COMMERCIAL.md).


### PR DESCRIPTION
The last three documents still carrying the rule that reserved the name
`TigerTag+` to signed tags. Same mechanical correction as #15 and #16, no
definition choice. These files are covered by CI as of #17, so this is
the first time the change is verified on the way in.

## `SECURITY.md` — the one that mattered

It listed as a reportable vulnerability:

> **Signature bypass** — causing a reader that follows the specification to accept an unsigned or invalidly signed tag as TigerTag+

That is now **correct behaviour**. The `+` is a catalogue identity, not an
authenticity claim, and an unsigned `TigerTag+` is normal. A security
policy that describes correct behaviour as a bypass sends researchers
after the wrong thing — and leaves them no wording for the real one: a
reader presenting an unsigned tag as **origin-verified**. That is what
the entry says now.

The downgrade entry carried the same conflation ("forcing a reader to
treat a TigerTag+ chip as an unsigned one") and now speaks of a validly
signed chip.

## `brand/README.md`

Forbade presenting a product as `TigerTag+` without a signature. The
restriction belongs to `TigerTag+ Certified`. The permitted case is
spelled out rather than left implicit, so the correction does not read as
an oversight later.

## `LICENSE_COMMERCIAL.md`

Unlicensed products "may not […] claim TigerTag+ status" — in a contract,
one clause away from a separate restriction on Official Product IDs,
which is precisely what TigerTag+ status now means. `TigerTag+ Certified`
status is what this Agreement actually gates.

## Result

With this, no document in the repository still ties the `+` to the
signature. `tools/docs_check.py` passes over all thirteen.