### PR TITLE
data: carry the renamed version tags into id_version.json

### DIFF
--- a/database/id_version.json
+++ b/database/id_version.json
@@ -10,7 +10,7 @@
     "id": 1542820452,
     "version": "1.0",
     "name": "TigerTag",
-    "tag": "TIGER_TAG_MAKER_V1.0",
+    "tag": "TIGER_TAG_V1.0",
     "public_key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwtX8JRYMoAXTbkU7EXJYKX7g4Mf0\nZ3WUuuGzlfyiEiS5UseXT6l1t1ZbMgzsg5IVA0TB7+/w6eyTlgnz/HXONw==\n-----END PUBLIC KEY-----"
   },
   {
@@ -24,7 +24,7 @@
     "id": 3155151767,
     "version": "1.0",
     "name": "TigerTag+",
-    "tag": "TIGER_TAG_PRO_V1.0",
+    "tag": "TIGER_TAG_PLUS_V1.0",
     "public_key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwtX8JRYMoAXTbkU7EXJYKX7g4Mf0\nZ3WUuuGzlfyiEiS5UseXT6l1t1ZbMgzsg5IVA0TB7+/w6eyTlgnz/HXONw==\n-----END PUBLIC KEY-----"
   }
 ]


### PR DESCRIPTION
`TIGER_TAG_MAKER_V1.0` → `TIGER_TAG_V1.0` and `TIGER_TAG_PRO_V1.0` →
`TIGER_TAG_PLUS_V1.0`, applied to `database/id_version.json`.

## Why this is a manual commit on a generated file

The scheduled sync did not pick the rename up, and a manual
`workflow_dispatch` of `sync-database.yml` did not either. The incremental
sync compares `all/last_update` with the local copy, and `versions` holds
the **same timestamp on both sides**:

| | `versions` |
|---|---|
| API `all/last_update` | `1788636538646` |
| `database/last_update.json` | `1788636538646` |

The table's content changed without its timestamp moving, so the sync
correctly concluded there was nothing to fetch. It skipped the file, and
would have kept skipping it.

**This commit is a stopgap, not the fix.** The fix is upstream: a change
to the version table has to bump its `last_update` entry. This is worth
treating as more than a one-off — §2.0 of the README recommends exactly
this timestamp mechanism to integrators, so anyone who followed it is
still serving `TIGER_TAG_PRO_V1.0` and will keep doing so.

Meanwhile the repository was contradicting itself: `VERSIONING.md` has
named the new tags since #16, while the JSON it points at named the old
ones.

## How the file was produced

From the live `version/get/all` endpoint, not by hand, using the same
serialisation as `download_dataset()` (`json.dumps(..., ensure_ascii=False,
indent=2)`), after asserting that the ids, the key set and the public keys
were unchanged.

The result is a two-line diff — the tag strings and nothing else — so the
next real sync produces no spurious change.