### PR TITLE
docs: list BambuTagger among the community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1253,6 +1253,19 @@ HACS-compatible custom integration that synchronises your TigerTag filament inve
 
 🔗 [Kenny3231/TigerTag](https://github.com/Kenny3231/TigerTag) — author: [@Kenny3231](https://github.com/Kenny3231). Per its own README, this is a community project **not officially affiliated with TigerTag Project**.
 
+### 6.4 BambuTagger — DIY tag reader/writer hardware
+
+Two open-hardware ESP32 builds that read and write **TigerTag** alongside Bambu Lab, SpoolEase, OpenSpool and OpenTag3D, each from off-the-shelf modules and a printed case:
+
+- **BT-Touch** — a handheld reader, writer and cloner: ESP32-S3 with a 5" touchscreen and one RC522, battery powered, with local storage for over 2 000 tags.
+- **BT-AMS-C** — a four-slot reader that sits on a Bambu Lab AMS, showing live slot data and pushing tag data to the printer/BMCU, configured over a web interface with OTA updates.
+
+Its TigerTag parser reads the binary format **at the offsets this specification defines** and accepts both `0x5BF59264` and `0xBC0FCB97`. It covers the identification and print-settings fields — material, aspects, brand, diameter, colour 1, measure with unit conversion, nozzle, bed and drying — and does not read Transmission Distance, the custom message, or the signature, so it neither verifies nor claims authenticity. The reference tables are compiled in as a snapshot rather than synced from [`database/`](database/), so newly catalogued brands and materials resolve only after a firmware update.
+
+Cloning is worth a word, since the device offers it: copying a signed chip reproduces the payload, not the signature's validity, which is the point of §3 — an attestation, never a lock.
+
+🔗 [bambutagger.de](https://www.bambutagger.de) · [VID-PRO/BambuTagger-Touch](https://github.com/VID-PRO/BambuTagger-Touch) — AGPL-3.0. Credits, on the author's own page, to BambuMan and the Bambu-Research-Group RFID-Tag-Guide.
+
 ---
 
 ## Press kit & brand assets

--- a/llms.txt
+++ b/llms.txt
@@ -273,6 +273,12 @@ integration, never as a thing bought on its own.
   https://github.com/Kenny3231/TigerTag
 - Snapmaker U1 Extended Firmware (TigerTag via OpenRFID):
   https://github.com/paxx12-snapmaker-u1/SnapmakerU1-Extended-Firmware
+- BambuTagger — DIY ESP32 reader/writer hardware (BT-Touch handheld,
+  BT-AMS-C four-slot AMS reader). Reads and writes the TigerTag binary
+  format at the specified offsets; does not read TD, the custom message
+  or the signature, so it makes no authenticity claim. Reference tables
+  are compiled in as a snapshot, not synced from database/.
+  https://www.bambutagger.de · https://github.com/VID-PRO/BambuTagger-Touch
 
 ---
 


### PR DESCRIPTION
Adds §6.4 for [bambutagger.de](https://www.bambutagger.de) — the first
third-party **hardware** in this list; everything else in §6 is software.

## What it is

- **BT-Touch** — a handheld reader, writer and cloner. ESP32-S3, 5"
  touchscreen, one RC522, battery, local storage for 2 000+ tags.
- **BT-AMS-C** — a four-slot reader that mounts on a Bambu Lab AMS,
  displays live slot data and pushes tag data to the printer/BMCU. Web
  configuration, OTA updates.

Both are DIY from off-the-shelf modules with printed cases and published
PCB files. AGPL-3.0.

## The compatibility claim was verified, not repeated

The product page says "TigerTag" among the formats it handles. Rather
than take that at face value, the parser in
[`src/main.cpp`](https://github.com/VID-PRO/BambuTagger-Touch/blob/main/src/main.cpp)
was read against §2 of this specification. Every offset matches:

| Field | Spec offset | Theirs |
|---|---|---|
| ID TigerTag | +0, u32 BE | ✅ |
| ID Material | +8, u16 BE | ✅ |
| Aspect 1 / 2 | +10 / +11 | ✅ |
| ID Diameter | +13 | ✅ |
| ID Brand | +14, u16 BE | ✅ |
| Colour 1 RGB | +16 | ✅ |
| Measure | +20, u24 BE | ✅ |
| ID Unit | +23 | ✅ (kg ×1000, mg ÷1000 — matches `id_measure_unit.json`) |
| Nozzle min / max | +24 / +26 | ✅ |
| Dry temp / time | +28 / +29 | ✅ |
| Bed min / max | +30 / +31 | ✅ |

It accepts both `0x5BF59264` and `0xBC0FCB97`, which is correct.

## And the limits are stated

Because someone reading §6 may be deciding whether to build one:

- It does **not** read Transmission Distance, the custom message, or the
  signature — so it makes no authenticity claim, and none should be read
  into it.
- Its reference tables are **compiled in as a snapshot**, not synced from
  [`database/`](database/), so newly catalogued brands and materials
  resolve only after a firmware update.

Cloning gets a line as well, since the device offers it and a reader of
§3 may wonder: copying a signed chip reproduces the payload, not the
signature's validity — the attestation-not-a-lock property this project
already documents.

The section's existing disclaimer covers it: community projects, not
maintained or endorsed by TigerTag Project.